### PR TITLE
(windows): Add ushort type definition for CUDA compilation for Sageattention 2.x

### DIFF
--- a/csrc/math.cuh
+++ b/csrc/math.cuh
@@ -21,6 +21,10 @@
 #pragma once
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#ifndef USHORT_TYPE
+#define USHORT_TYPE
+typedef unsigned short ushort;
+#endif
 
 namespace math {
 


### PR DESCRIPTION
This addresses the "identifier 'ushort' is undefined" error in math.cuh without affecting other platforms.