### PR TITLE
Support MSVC compiler flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,8 @@ SUPPORTED_ARCHS = {"8.0", "8.6", "8.9", "9.0", "12.0"}
 if os.name == "nt":
     # TODO: Detect MSVC
     CXX_FLAGS = ["/O2", "/openmp", "/std:c++17", "-DENABLE_BF16"]
-    EXTRA_LINK_ARGS = ["cuda.lib"]
 else:
     CXX_FLAGS = ["-g", "-O3", "-fopenmp", "-lgomp", "-std=c++17", "-DENABLE_BF16"]
-    EXTRA_LINK_ARGS = ["-lcuda"]
 NVCC_FLAGS = [
     "-O3",
     "-std=c++17",
@@ -159,11 +157,11 @@ if HAS_SM90:
             "csrc/qattn/pybind_sm90.cpp",
             "csrc/qattn/qk_int_sv_f8_cuda_sm90.cu",
         ],
+        libraries=["cuda"],
         extra_compile_args={
             "cxx": CXX_FLAGS,
             "nvcc": NVCC_FLAGS,
         },
-        extra_link_args=EXTRA_LINK_ARGS,
     )
     ext_modules.append(qattn_extension)
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,13 @@ HAS_SM120 = False
 SUPPORTED_ARCHS = {"8.0", "8.6", "8.9", "9.0", "12.0"}
 
 # Compiler flags.
-CXX_FLAGS = ["-g", "-O3", "-fopenmp", "-lgomp", "-std=c++17", "-DENABLE_BF16"]
+if os.name == "nt":
+    # TODO: Detect MSVC
+    CXX_FLAGS = ["/O2", "/openmp", "/std:c++17", "-DENABLE_BF16"]
+    EXTRA_LINK_ARGS = ["cuda.lib"]
+else:
+    CXX_FLAGS = ["-g", "-O3", "-fopenmp", "-lgomp", "-std=c++17", "-DENABLE_BF16"]
+    EXTRA_LINK_ARGS = ["-lcuda"]
 NVCC_FLAGS = [
     "-O3",
     "-std=c++17",
@@ -157,7 +163,7 @@ if HAS_SM90:
             "cxx": CXX_FLAGS,
             "nvcc": NVCC_FLAGS,
         },
-        extra_link_args=['-lcuda'],
+        extra_link_args=EXTRA_LINK_ARGS,
     )
     ext_modules.append(qattn_extension)
 


### PR DESCRIPTION
This is needed for building on Windows with MSVC and sm90.

Technically one can also build on Windows using GCC or other compilers, but detecting this in a reliable way (such as using `distutils`) would make the build script more complicated. It's much easier to use MSVC when dealing with CUDA on Windows, and it's the default in most CI runners. So for now we only detect `os.name == "nt"`