### PR TITLE
Update core.py Fix for CUDA <12.8

### DIFF
--- a/sageattention/core.py
+++ b/sageattention/core.py
@@ -55,7 +55,8 @@ import warnings
 
 import subprocess
 import re
-def get_cuda_version():
+# Get CUDA version once at module load
+def _detect_cuda_version():
     try:
         output = subprocess.check_output(['nvcc', '--version']).decode()
         match = re.search(r'release (\d+)\.(\d+)', output)
@@ -65,6 +66,13 @@ def get_cuda_version():
     except Exception as e:
         print("Failed to get CUDA version:", e)
     return None, None
+
+# Store it in a module-level variable
+_CUDA_VERSION = _detect_cuda_version()
+
+# Now the function just returns the cached value
+def get_cuda_version():
+    return _CUDA_VERSION
 
 def get_cuda_arch_versions():
     cuda_archs = []


### PR DESCRIPTION
Fix for CUDA <12.8 to fallback with warning "cuda version < 12.8, change pv_accum_dtype to 'fp32+fp32'"

Pls recompile with these changes (uncommenting lines 687-690 in sageattention/core.py). 

Without these changes:
On my CUDA 12.5 setup on 4090, Upgrading from Sage Attention 1.0.6 to Sage Attention 2.2.0 gave me the following error

`terminate called after throwing an instance of 'c10::Error'
  what():  CUDA error: unspecified launch failure
Compile with TORCH_USE_CUDA_DSA to enable device-side assertions.

Exception raised from c10_cuda_check_implementation at /pytorch/c10/cuda/CUDAException.cpp:43 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x98 (0x7fab780f45e8 in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) + 0xe0 (0x7fab780894a2 in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #2: c10::cuda::c10_cuda_check_implementation(int, char const*, char const*, int, bool) + 0x3c2 (0x7fab781d2292 in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libc10_cuda.so)
frame #3: <unknown function> + 0x5d213 (0x7fab781d9213 in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libc10_cuda.so)
frame #4: <unknown function> + 0x44c172 (0x7fab6ee4c172 in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #5: c10::TensorImpl::~TensorImpl() + 0x9 (0x7fab780cef39 in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libc10.so)
frame #6: <unknown function> + 0x7033e8 (0x7fab6f1033e8 in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #7: <unknown function> + 0x703810 (0x7fab6f103810 in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
<omitting python frames>
frame #10: <unknown function> + 0x72e2ad (0x7fab6f12e2ad in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #13: dynamo_eval_custom_code + 0x1fe (0x7fab6f12d17e in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #14: <unknown function> + 0x72e1ac (0x7fab6f12e1ac in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #17: dynamo_eval_custom_code + 0x1fe (0x7fab6f12d17e in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #18: <unknown function> + 0x72e1ac (0x7fab6f12e1ac in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #21: dynamo_eval_custom_code + 0x1fe (0x7fab6f12d17e in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #22: <unknown function> + 0x72e05b (0x7fab6f12e05b in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #25: dynamo_eval_custom_code + 0x1fe (0x7fab6f12d17e in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #26: <unknown function> + 0x72e05b (0x7fab6f12e05b in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #29: dynamo_eval_custom_code + 0x1fe (0x7fab6f12d17e in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #30: <unknown function> + 0x72e05b (0x7fab6f12e05b in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #35: <unknown function> + 0x72e2ad (0x7fab6f12e2ad in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)
frame #40: <unknown function> + 0x72e2ad (0x7fab6f12e2ad in /home/umer/anaconda3/envs/comfyui/lib/python3.12/site-packages/torch/lib/libtorch_python.so)

Aborted (core dumped)`