### PR TITLE
Fix mask computation for better precision

### DIFF
--- a/sageattention/triton/attn_qk_int8_block_varlen.py
+++ b/sageattention/triton/attn_qk_int8_block_varlen.py
@@ -32,9 +32,12 @@ def _attn_fwd_inner(acc, l_i, m_i, q, q_scale, kv_len,
         k_mask = offs_n[None, :] < (kv_len - start_n)   
         k = tl.load(K_ptrs, mask = k_mask)
         k_scale = tl.load(K_scale_ptr)
-        qk = tl.dot(q, k).to(tl.float32) * q_scale * k_scale 
+        qk = tl.dot(q, k).to(tl.float32) * (q_scale * k_scale)
+
+        qk += tl.where(k_mask, 0, float('-inf'))
         m_ij = tl.maximum(m_i, tl.max(qk, 1))
         qk = qk - m_ij[:, None]
+
         p = tl.math.exp2(qk)
         l_ij = tl.sum(p, 1)
         

--- a/sageattention/triton/attn_qk_int8_per_block.py
+++ b/sageattention/triton/attn_qk_int8_per_block.py
@@ -31,9 +31,12 @@ def _attn_fwd_inner(acc, l_i, m_i, q, q_scale, kv_len,
         k_mask = offs_n[None, :] < (kv_len - start_n)   
         k = tl.load(K_ptrs, mask = k_mask)
         k_scale = tl.load(K_scale_ptr)
-        qk = tl.dot(q, k).to(tl.float32) * q_scale * k_scale 
+        qk = tl.dot(q, k).to(tl.float32) * (q_scale * k_scale)
+        
+        qk += tl.where(k_mask, 0, float('-inf'))
         m_ij = tl.maximum(m_i, tl.max(qk, 1))
         qk = qk - m_ij[:, None]
+
         p = tl.math.exp2(qk)
         l_ij = tl.sum(p, 1)
         

--- a/sageattention/triton/attn_qk_int8_per_block_causal_varlen.py
+++ b/sageattention/triton/attn_qk_int8_per_block_causal_varlen.py
@@ -39,16 +39,14 @@ def _attn_fwd_inner(acc, l_i, m_i, q, q_scale, kv_len,
         k_mask = offs_n[None, :] < (kv_len - start_n)   
         k = tl.load(K_ptrs, mask = k_mask)
         k_scale = tl.load(K_scale_ptr)
-        qk = tl.dot(q, k).to(tl.float32) * q_scale * k_scale 
+        qk = tl.dot(q, k).to(tl.float32) * (q_scale * k_scale)
 
+        mask = k_mask
         if STAGE == 2:
-            mask = offs_m[:, None] >= (start_n + offs_n[None, :])
-            qk = qk + tl.where(mask, 0, -1.0e6)
-            m_ij = tl.maximum(m_i, tl.max(qk, 1))
-            qk -= m_ij[:, None]
-        else:
-            m_ij = tl.maximum(m_i, tl.max(qk, 1))
-            qk = qk - m_ij[:, None]
+            mask &= offs_m[:, None] >= (start_n + offs_n[None, :])
+        qk += tl.where(mask, 0, float('-inf'))
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        qk -= m_ij[:, None]
         
         p = tl.math.exp2(qk)
         l_ij = tl.sum(p, 1)


### PR DESCRIPTION
‌During the forward pass, the unnecessary parts are not masked out after computing `qk`. When elements in `qk` are far below zero, this causes the computed `m` to be far larger than it should be, leading to a loss of precision.

This PR aims to fix the mask computation.