### PR TITLE
Set device to `query.device` to be consistent with C code

### DIFF
--- a/sageattention/sm80_compile.py
+++ b/sageattention/sm80_compile.py
@@ -2,7 +2,7 @@ from . import _qattn_sm80
 import torch
 
 
-@torch.library.custom_op("sageattention::qk_int8_sv_f16_accum_f16_attn", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention::qk_int8_sv_f16_accum_f16_attn", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f16_accum_f16_attn(
     query: torch.Tensor, 
     key: torch.Tensor, 
@@ -25,7 +25,7 @@ def qk_int8_sv_f16_accum_f16_attn(
     )
 
 
-@torch.library.custom_op("sageattention::qk_int8_sv_f16_accum_f32_attn", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention::qk_int8_sv_f16_accum_f32_attn", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f16_accum_f32_attn(
     query: torch.Tensor, 
     key: torch.Tensor, 
@@ -48,7 +48,7 @@ def qk_int8_sv_f16_accum_f32_attn(
     )
 
 
-@torch.library.custom_op("sageattention::qk_int8_sv_f16_accum_f16_attn_inst_buf", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention::qk_int8_sv_f16_accum_f16_attn_inst_buf", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f16_accum_f16_attn_inst_buf(
     query: torch.Tensor, 
     key: torch.Tensor, 
@@ -71,7 +71,7 @@ def qk_int8_sv_f16_accum_f16_attn_inst_buf(
     )
 
 
-@torch.library.custom_op("sageattention::qk_int8_sv_f16_accum_f16_fuse_v_mean_attn", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention::qk_int8_sv_f16_accum_f16_fuse_v_mean_attn", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f16_accum_f16_fuse_v_mean_attn(
     query: torch.Tensor, 
     key: torch.Tensor, 

--- a/sageattention/sm89_compile.py
+++ b/sageattention/sm89_compile.py
@@ -2,7 +2,7 @@ from . import _qattn_sm89
 import torch
 
 
-@torch.library.custom_op("sageattention_sm89::qk_int8_sv_f8_accum_f32_fuse_v_scale_attn", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention_sm89::qk_int8_sv_f8_accum_f32_fuse_v_scale_attn", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f8_accum_f32_fuse_v_scale_attn(
     query: torch.Tensor, 
     key: torch.Tensor, 
@@ -24,7 +24,7 @@ def qk_int8_sv_f8_accum_f32_fuse_v_scale_attn(
 
 
 
-@torch.library.custom_op("sageattention_sm89::qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention_sm89::qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(
     query: torch.Tensor, 
     key: torch.Tensor, 
@@ -45,7 +45,7 @@ def qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(
     )
 
 
-@torch.library.custom_op("sageattention_sm89::qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention_sm89::qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf(
     query: torch.Tensor, 
     key: torch.Tensor, 
@@ -101,7 +101,7 @@ torch.library.register_fake("sageattention_sm89::qk_int8_sv_f8_accum_f16_fuse_v_
 torch.library.register_fake("sageattention_sm89::qk_int8_sv_f8_accum_f32_fuse_v_scale_attn")(sm89_qk_with_key_value)
 
 
-@torch.library.custom_op("sageattention_sm89::qk_int8_sv_f8_accum_f32_fuse_v_scale_fuse_v_mean_attn", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention_sm89::qk_int8_sv_f8_accum_f32_fuse_v_scale_fuse_v_mean_attn", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f8_accum_f32_fuse_v_scale_fuse_v_mean_attn(
     query: torch.Tensor, 
     key: torch.Tensor, 

--- a/sageattention/sm90_compile.py
+++ b/sageattention/sm90_compile.py
@@ -2,7 +2,7 @@ from . import _qattn_sm90
 import torch
 
 
-@torch.library.custom_op("sageattention_sm90::qk_int8_sv_f8_accum_f32_attn_inst_buf", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention_sm90::qk_int8_sv_f8_accum_f32_attn_inst_buf", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f8_accum_f32_attn_inst_buf(
     query: torch.Tensor, 
     key: torch.Tensor, 
@@ -52,7 +52,7 @@ def qk_int8_sv_f8_accum_f32_attn_inst_buf_fake_impl(
     return lse
 
 
-@torch.library.custom_op("sageattention_sm90::qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf", mutates_args=("output"), device_types="cuda")
+@torch.library.custom_op("sageattention_sm90::qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf", mutates_args=("output",), device_types="cuda")
 def qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(
     query: torch.Tensor, 
     key: torch.Tensor, 


### PR DESCRIPTION
This is a follow-up PR of https://github.com/thu-ml/SageAttention/pull/218 which sets the device of `lse` to be the same as `query`, as suggested by @woct0rdho