### PR TITLE
Support head dim 256

### DIFF
--- a/bench/bench_qk_int8_pv_fp16_cuda.py
+++ b/bench/bench_qk_int8_pv_fp16_cuda.py
@@ -20,7 +20,7 @@ headdim = args.head_dim
 print(f"CUDA QK Int8 PV FP16 Benchmark")
 print(f"batch: {batch}, head: {head}, headdim: {headdim}, pv_accum_dtype: {args.pv_accum_dtype}")
 
-WARP_Q = 16 if (headdim == 128 and args.pv_accum_dtype == "fp16+fp32") else 32
+WARP_Q = 16 if (headdim > 64 and args.pv_accum_dtype == "fp16+fp32") else 32
 WARP_K = 64
 
 if args.pv_accum_dtype == 'fp32':

--- a/bench/bench_qk_int8_pv_fp16_cuda.py
+++ b/bench/bench_qk_int8_pv_fp16_cuda.py
@@ -20,8 +20,18 @@ headdim = args.head_dim
 print(f"CUDA QK Int8 PV FP16 Benchmark")
 print(f"batch: {batch}, head: {head}, headdim: {headdim}, pv_accum_dtype: {args.pv_accum_dtype}")
 
-WARP_Q = 16 if (headdim > 64 and args.pv_accum_dtype == "fp16+fp32") else 32
-WARP_K = 64
+def div_ceil(a, b):
+    return (a + b - 1) // b
+
+def tile_config(is_causal):
+    if args.pv_accum_dtype in ["fp16", "fp32"] and headdim == 256:
+        return 128, 64, 16, 64
+    if args.pv_accum_dtype == "fp16+fp32":
+        if headdim == 128 and not is_causal:
+            return 128, 32, 32, 32
+        if headdim > 64:
+            return 128, 64, 16, 64
+    return 128, 64, 32, 64
 
 if args.pv_accum_dtype == 'fp32':
     kernel = qattn.qk_int8_sv_f16_accum_f32_attn # the kernel with fully fp32 accumulator
@@ -35,6 +45,7 @@ _qk_quant_gran = 3 if args.quant_gran == 'per_thread' else 2
 is_causal = False
 _is_causal = 1 if is_causal else 0
 print(f"is_causal: {is_causal}")
+BLK_Q, BLK_K, WARP_Q, WARP_K = tile_config(is_causal)
 for seq_len in {1024, 2048, 4096, 8192, 16384, 32768}:
     flops = 4 * head * batch * headdim * seq_len * seq_len / (2 if is_causal else 1)
     
@@ -44,11 +55,11 @@ for seq_len in {1024, 2048, 4096, 8192, 16384, 32768}:
     vm = torch.randn(batch, head, headdim, dtype=torch.float16, device="cuda")
 
     if args.quant_gran == 'per_warp':
-        q_scale = torch.randn(batch, head, seq_len // WARP_Q, dtype=torch.float, device="cuda")
-        k_scale = torch.randn(batch, head, seq_len // WARP_K, dtype=torch.float, device="cuda")
+        q_scale = torch.randn(batch, head, div_ceil(seq_len, BLK_Q) * (BLK_Q // WARP_Q), dtype=torch.float, device="cuda")
+        k_scale = torch.randn(batch, head, div_ceil(seq_len, BLK_K) * (BLK_K // WARP_K), dtype=torch.float, device="cuda")
     elif args.quant_gran == 'per_thread':
-        q_scale = torch.randn(batch, head, seq_len // WARP_Q * 8, dtype=torch.float, device="cuda")
-        k_scale = torch.randn(batch, head, seq_len // WARP_K * 4, dtype=torch.float, device="cuda")
+        q_scale = torch.randn(batch, head, div_ceil(seq_len, BLK_Q) * (BLK_Q // WARP_Q) * 8, dtype=torch.float, device="cuda")
+        k_scale = torch.randn(batch, head, div_ceil(seq_len, BLK_K) * (BLK_K // WARP_K) * 4, dtype=torch.float, device="cuda")
    
     v = torch.randn(batch, seq_len, head, headdim, dtype=torch.float16, device="cuda")
     o = torch.empty(batch, seq_len, head, headdim, dtype=torch.float16, device="cuda")
@@ -61,6 +72,7 @@ for seq_len in {1024, 2048, 4096, 8192, 16384, 32768}:
 is_causal = True
 _is_causal = 1 if is_causal else 0
 print(f"is_causal: {is_causal}")
+BLK_Q, BLK_K, WARP_Q, WARP_K = tile_config(is_causal)
 for seq_len in {1024, 2048, 4096, 8192, 16384, 32768}:
     flops = 4 * head * batch * headdim * seq_len * seq_len / (2 if is_causal else 1)
     
@@ -70,11 +82,11 @@ for seq_len in {1024, 2048, 4096, 8192, 16384, 32768}:
     vm = torch.randn(batch, head, headdim, dtype=torch.float16, device="cuda")
 
     if args.quant_gran == 'per_warp':
-        q_scale = torch.randn(batch, head, seq_len // WARP_Q, dtype=torch.float, device="cuda")
-        k_scale = torch.randn(batch, head, seq_len // WARP_K, dtype=torch.float, device="cuda")
+        q_scale = torch.randn(batch, head, div_ceil(seq_len, BLK_Q) * (BLK_Q // WARP_Q), dtype=torch.float, device="cuda")
+        k_scale = torch.randn(batch, head, div_ceil(seq_len, BLK_K) * (BLK_K // WARP_K), dtype=torch.float, device="cuda")
     elif args.quant_gran == 'per_thread':
-        q_scale = torch.randn(batch, head, seq_len // WARP_Q * 8, dtype=torch.float, device="cuda")
-        k_scale = torch.randn(batch, head, seq_len // WARP_K * 4, dtype=torch.float, device="cuda")
+        q_scale = torch.randn(batch, head, div_ceil(seq_len, BLK_Q) * (BLK_Q // WARP_Q) * 8, dtype=torch.float, device="cuda")
+        k_scale = torch.randn(batch, head, div_ceil(seq_len, BLK_K) * (BLK_K // WARP_K) * 4, dtype=torch.float, device="cuda")
    
     v = torch.randn(batch, seq_len, head, headdim, dtype=torch.float16, device="cuda")
     o = torch.empty(batch, seq_len, head, headdim, dtype=torch.float16, device="cuda")

--- a/bench/bench_qk_int8_pv_fp8_cuda.py
+++ b/bench/bench_qk_int8_pv_fp8_cuda.py
@@ -35,7 +35,7 @@ fused_v = args.fused_v
 print(f"CUDA QK Int8 PV FP8 Benchmark")
 print(f"batch: {batch}, head: {head}, headdim: {headdim}, pv_accum_dtype: {args.pv_accum_dtype}, fused_v: {fused_v}")
 
-WARP_Q = 32
+WARP_Q = 16 if headdim == 256 else 32
 WARP_K = 64
 
 #fused_v = False

--- a/csrc/dispatch_utils.h
+++ b/csrc/dispatch_utils.h
@@ -27,6 +27,9 @@
   } else if (head_dim == 128) {                                 \
     constexpr int HEAD_DIM = 128;                               \
     __VA_ARGS__                                                 \
+  } else if (head_dim == 256) {                                 \
+    constexpr int HEAD_DIM = 256;                               \
+    __VA_ARGS__                                                 \
   } else {                                                      \
     std::ostringstream err_msg;                                 \
     err_msg << "Unsupported head dim: " << int(head_dim);       \

--- a/csrc/qattn/qk_int_sv_f16_cuda_sm80.cu
+++ b/csrc/qattn/qk_int_sv_f16_cuda_sm80.cu
@@ -61,7 +61,7 @@ __global__ void qk_int_sv_f16_attn_kernel(int8_t *__restrict__ Q, int8_t *__rest
   static_assert(std::is_same<DTypeOut, half>::value || std::is_same<DTypeOut, nv_bfloat16>::value, "DTypeOut must be half or nv_bfloat16");
   static_assert(head_dim % 64 == 0, "head_dim must be a multiple of 64");
   static_assert(!fuse_v_mean || std::is_same<DTypeSVAccum, half>::value, "fuse_v_mean only supports half");
-  static_assert(CTA_Q / CTA_K <= 2); // for efficient causal implementation
+  static_assert(mask_mode != MaskMode::kCausal || CTA_Q / CTA_K <= 2); // for efficient causal implementation
 
   using DTypeOut2 = typename std::conditional<std::is_same<DTypeOut, half>::value, half2, nv_bfloat162>::type;
 
@@ -788,7 +788,7 @@ torch::Tensor qk_int8_sv_f16_accum_f32_attn(torch::Tensor query,
           DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(output_dtype, DTypeOut, {
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             constexpr MaskMode mask_mode = IS_CAUSAL ? MaskMode::kCausal : MaskMode::kNone;
@@ -963,7 +963,7 @@ torch::Tensor qk_int8_sv_f16_accum_f16_attn(torch::Tensor query,
               
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             constexpr MaskMode mask_mode = IS_CAUSAL ? MaskMode::kCausal : MaskMode::kNone;
@@ -1137,9 +1137,10 @@ torch::Tensor qk_int8_sv_f16_accum_f16_attn_inst_buf(torch::Tensor query,
           DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(output_dtype, DTypeOut, {
               
             constexpr int CTA_Q = 128;
-            constexpr int CTA_K = 64;
-            constexpr int WARP_Q = (HEAD_DIM == 64) ? 32 : 16;
-            constexpr int WARP_K = 64;
+            constexpr bool USE_NON_CAUSAL_HD128_TILE = !IS_CAUSAL && HEAD_DIM == 128;
+            constexpr int CTA_K = USE_NON_CAUSAL_HD128_TILE ? 32 : 64;
+            constexpr int WARP_Q = (HEAD_DIM == 64 || USE_NON_CAUSAL_HD128_TILE) ? 32 : 16;
+            constexpr int WARP_K = USE_NON_CAUSAL_HD128_TILE ? 32 : 64;
 
             constexpr MaskMode mask_mode = IS_CAUSAL ? MaskMode::kCausal : MaskMode::kNone;
 
@@ -1320,7 +1321,7 @@ torch::Tensor qk_int8_sv_f16_accum_f16_fuse_v_mean_attn(torch::Tensor query,
               
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             constexpr MaskMode mask_mode = IS_CAUSAL ? MaskMode::kCausal : MaskMode::kNone;

--- a/csrc/qattn/qk_int_sv_f8_cuda_sm90.cu
+++ b/csrc/qattn/qk_int_sv_f8_cuda_sm90.cu
@@ -26,6 +26,21 @@
 
 #include "attn_utils.cuh"
 
+#define DISPATCH_HEAD_DIM_SM90(head_dim, HEAD_DIM, ...)           \
+  if (head_dim == 64) {                                           \
+    constexpr int HEAD_DIM = 64;                                  \
+    __VA_ARGS__                                                   \
+  } else if (head_dim == 128) {                                   \
+    constexpr int HEAD_DIM = 128;                                 \
+    __VA_ARGS__                                                   \
+  } else {                                                        \
+    std::ostringstream err_msg;                                   \
+    err_msg << "SM90 kernel does not support head_dim="          \
+            << int(head_dim) << ". Only 64 and 128 are supported. " \
+            << "Use SM80 or SM89 kernels for head_dim=256.";     \
+    throw std::invalid_argument(err_msg.str());                   \
+  }
+
 template <int BlockMajorSize, int BlockMinorSize, bool swizzle=true, CUtensorMapL2promotion_enum promotion_mode=CU_TENSOR_MAP_L2_PROMOTION_NONE, typename T>
 CUtensorMap create_tensor_map_4D(T* gmem_ptr, int d1, int d2, int d3, int d4, int stride1, int stride2, int stride3) {
     constexpr int smem_stride = BlockMinorSize * sizeof(T);
@@ -678,7 +693,7 @@ torch::Tensor qk_int8_sv_f8_accum_f32_attn_inst_buf(
 
   auto output_type = output.scalar_type();
 
-  DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
+  DISPATCH_HEAD_DIM_SM90(head_dim, HEAD_DIM, {
     DISPATCH_CAUSAL(is_causal, IS_CAUSAL, {
       DISPATCH_QK_QUANT_GRAN(qk_quant_gran, QK_QUANT_GRAN, {
         DISPATCH_RETURN_LSE(return_lse, RETURN_LSE, {
@@ -854,7 +869,7 @@ torch::Tensor qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(
 
   auto output_dtype = output.scalar_type();
 
-  DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
+  DISPATCH_HEAD_DIM_SM90(head_dim, HEAD_DIM, {
     DISPATCH_CAUSAL(is_causal, IS_CAUSAL, {
       DISPATCH_QK_QUANT_GRAN(qk_quant_gran, QK_QUANT_GRAN, {
         DISPATCH_RETURN_LSE(return_lse, RETURN_LSE, {

--- a/csrc/qattn/sm89_qk_int8_sv_f8_accum_f16_attn_inst_buf.cu
+++ b/csrc/qattn/sm89_qk_int8_sv_f8_accum_f16_attn_inst_buf.cu
@@ -118,7 +118,7 @@ torch::Tensor qk_int8_sv_f8_accum_f16_attn_inst_buf(torch::Tensor query,
           DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(output_dtype, DTypeOut, {
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             assert(value.size(0) == batch_size);

--- a/csrc/qattn/sm89_qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf.cu
+++ b/csrc/qattn/sm89_qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf.cu
@@ -123,7 +123,7 @@ torch::Tensor qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf(torch::Tensor q
               
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             assert(value.size(0) == batch_size);

--- a/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_attn.cu
+++ b/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_attn.cu
@@ -118,7 +118,7 @@ torch::Tensor qk_int8_sv_f8_accum_f32_attn(torch::Tensor query,
           DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(output_dtype, DTypeOut, {
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             assert(value.size(0) == batch_size);

--- a/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_attn_inst_buf.cu
+++ b/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_attn_inst_buf.cu
@@ -117,7 +117,7 @@ torch::Tensor qk_int8_sv_f8_accum_f32_attn_inst_buf(torch::Tensor query,
           DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(output_dtype, DTypeOut, {
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             assert(value.size(0) == batch_size);

--- a/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_fuse_v_scale_attn.cu
+++ b/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_fuse_v_scale_attn.cu
@@ -123,7 +123,7 @@ torch::Tensor qk_int8_sv_f8_accum_f32_fuse_v_scale_attn(torch::Tensor query,
               
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             assert(value.size(0) == batch_size);

--- a/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf.cu
+++ b/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf.cu
@@ -123,7 +123,7 @@ torch::Tensor qk_int8_sv_f8_accum_f32_fuse_v_scale_attn_inst_buf(torch::Tensor q
               
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             assert(value.size(0) == batch_size);

--- a/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_fuse_v_scale_fuse_v_mean_attn.cu
+++ b/csrc/qattn/sm89_qk_int8_sv_f8_accum_f32_fuse_v_scale_fuse_v_mean_attn.cu
@@ -127,7 +127,7 @@ torch::Tensor qk_int8_sv_f8_accum_f32_fuse_v_scale_fuse_v_mean_attn(torch::Tenso
           DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(output_dtype, DTypeOut, {
             constexpr int CTA_Q = 128;
             constexpr int CTA_K = 64;
-            constexpr int WARP_Q = 32;
+            constexpr int WARP_Q = (HEAD_DIM == 256) ? 16 : 32;
             constexpr int WARP_K = 64;
 
             assert(value.size(0) == batch_size);

--- a/sageattention/core.py
+++ b/sageattention/core.py
@@ -584,10 +584,11 @@ def sageattn_qk_int8_pv_fp16_cuda(
     else:
         km = None
 
+    warp_q = 16 if (q.size(-1) > 64 and pv_accum_dtype == "fp16+fp32") else 32
     if qk_quant_gran == "per_warp":
-        q_int8, q_scale, k_int8, k_scale = per_warp_int8_cuda(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=(16 if (q.size(-1) == 128 and pv_accum_dtype == "fp16+fp32") else 32), BLKK=64)
+        q_int8, q_scale, k_int8, k_scale = per_warp_int8_cuda(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=warp_q, BLKK=64)
     elif qk_quant_gran == "per_thread":
-        q_int8, q_scale, k_int8, k_scale = per_thread_int8_triton(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=(16 if (q.size(-1) == 128 and pv_accum_dtype == "fp16+fp32") else 32), BLKK=64, WARPK=64)
+        q_int8, q_scale, k_int8, k_scale = per_thread_int8_triton(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=warp_q, BLKK=64, WARPK=64)
 
     o = torch.empty(q.size(), dtype=dtype, device=q.device)
 

--- a/sageattention/core.py
+++ b/sageattention/core.py
@@ -584,11 +584,20 @@ def sageattn_qk_int8_pv_fp16_cuda(
     else:
         km = None
 
-    warp_q = 16 if (q.size(-1) > 64 and pv_accum_dtype == "fp16+fp32") else 32
+    head_dim = q.size(-1)
+    blk_q, blk_k, warp_q, warp_k = 128, 64, 32, 64
+    if pv_accum_dtype in ["fp16", "fp32"] and head_dim == 256:
+        warp_q = 16
+    elif pv_accum_dtype == "fp16+fp32":
+        if head_dim == 128 and not is_causal:
+            blk_k, warp_q, warp_k = 32, 32, 32
+        elif head_dim > 64:
+            warp_q = 16
+
     if qk_quant_gran == "per_warp":
-        q_int8, q_scale, k_int8, k_scale = per_warp_int8_cuda(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=warp_q, BLKK=64)
+        q_int8, q_scale, k_int8, k_scale = per_warp_int8_cuda(q, k, km, tensor_layout=tensor_layout, BLKQ=blk_q, WARPQ=warp_q, BLKK=blk_k)
     elif qk_quant_gran == "per_thread":
-        q_int8, q_scale, k_int8, k_scale = per_thread_int8_triton(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=warp_q, BLKK=64, WARPK=64)
+        q_int8, q_scale, k_int8, k_scale = per_thread_int8_triton(q, k, km, tensor_layout=tensor_layout, BLKQ=blk_q, WARPQ=warp_q, BLKK=blk_k, WARPK=warp_k)
 
     o = torch.empty(q.size(), dtype=dtype, device=q.device)
 
@@ -763,10 +772,12 @@ def sageattn_qk_int8_pv_fp8_cuda(
     else:
         km = None
 
+    head_dim = q.size(-1)
+    warp_q = 16 if head_dim == 256 else 32
     if qk_quant_gran == "per_warp":
-        q_int8, q_scale, k_int8, k_scale = per_warp_int8_cuda(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=32, BLKK=64)
+        q_int8, q_scale, k_int8, k_scale = per_warp_int8_cuda(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=warp_q, BLKK=64)
     elif qk_quant_gran == "per_thread":
-        q_int8, q_scale, k_int8, k_scale = per_thread_int8_triton(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=32, BLKK=64, WARPK=64)
+        q_int8, q_scale, k_int8, k_scale = per_thread_int8_triton(q, k, km, tensor_layout=tensor_layout, BLKQ=128, WARPQ=warp_q, BLKK=64, WARPK=64)
 
     o = torch.empty(q.size(), dtype=dtype, device=q.device)
 


### PR DESCRIPTION
Head dim 256 is needed for models like AuraFlow and Ideogram 4. This PR adds it in the CUDA kernels. Later we can also add it in the Triton kernels if needed.

I've tested on RTX 3080 (sm86) and RTX 4090 (sm89). When seq len is large, they reach ~2x speedup compared to FlashAttention.

As always, `pv_accum_dtype="fp16+fp32"` (or `"fp32+fp16"` in some interfaces) is faster than `pv_accum_dtype="fp32"`, and `pv_accum_dtype="fp16"` is even faster, but more likely to cause black/noise/degraded output. Maybe the time has come that we have to tune it for each model.

Currently sm90 is not supported due to constraint of WGMMA size. If you have sm90, you can help make it work.

## Implementation details

When `head_dim == 256`, in `transpose_pad_permute_cuda`, we reduce `CTA_SIZE` on device to 32 so the assert `CTA_SIZE * HEAD_DIM <= 8192` (1024 threads per block) is satisfied. In all attn kernels, we reduce `WARP_Q` to 16 because of register pressure.

By the way, I've applied a patch although it's not related to head dim 256: In sm80 attn kernels, when `head_dim == 128` and `pv_accum_dtype == "fp16+fp32"` and non-causal, we should set `(CTA_Q, CTQ_K, WARP_Q, WARP_K)` to `(128, 32, 32, 32)`, because of how the inst buf works. This gives 2x or even 3x speedup and actually makes `pv_accum_dtype="fp16+fp32"` usable. I found it when benchmarking all configs with common ComfyUI workloads on sm86. In summary, the benchmarked workloads are:
```
batch_size = 1
num_heads = [16, 32]
seq_len = [1024, 2048, 4096, 8192]
head_dim = [64, 128, 256]
pv_accum_dtype = [fp16, fp16+fp32, fp32]
```
And the heuristic configs `(CTA_Q, CTQ_K, WARP_Q, WARP_K)` on sm86 are:
```
pv_accum_dtype=fp16 or fp32:
head_dim= 64: (128, 64, 32, 64)
head_dim=128: (128, 64, 32, 64)
head_dim=256: (128, 64, 16, 64)

pv_accum_dtype=fp16+fp32:
head_dim= 64: (128, 64, 32, 64)
head_dim=128: (128, 64, 16, 64) if causal else (128, 32, 32, 32)
head_dim=256: (128, 64, 16, 64)
```
Maybe there are similar cases in the seven sm89 attn kernels but I haven't looked.