### PR TITLE
feat: add Intel GPU (XPU) support via auto-round-lib dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ export EXT_PARALLEL=4 NVCC_APPEND_FLAGS="--threads 8" MAX_JOBS=32 # Optional
 python setup.py install
 ```
 
+### Intel GPU (XPU) Installation
+
+```bash
+# 1. Install PyTorch for XPU
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
+
+# 2. Install auto-round-lib (ARK kernels)
+pip install auto-round-lib
+
+# 3. Install SageAttention (CUDA compilation skipped automatically on XPU)
+git clone https://github.com/luoyu-intel/SageAttention.git
+cd SageAttention
+python setup.py install
+```
+
+On XPU systems, `sageattn()` automatically uses the ARK kernel (sageV1) via `auto-round-lib`.
+Supported head dimensions: 64, 128. Supported dtypes: FP16, BF16.
+
 To benchmark the speed against FlashAttention3, please compile FlashAttention3 from source:
 ```
 git clone https://github.com/Dao-AILab/flash-attention.git --recursive
@@ -115,6 +133,8 @@ attn_output = sageattn(q, k, v, tensor_layout="HND", is_causal=False)
 + `sageattn_qk_int8_pv_fp8_cuda`: INT8 quantization for $QK^\top$ and FP8 for $PV$ using CUDA backend. (Note that setting `pv_accum_dtype=fp32+fp16` corresponds to SageAttention2++.)
 + `sageattn_qk_int8_pv_fp8_cuda_sm90`: INT8 quantization for $QK^\top$ and FP8 for $PV$ using CUDA backend, specifically optimized for Hopper GPUs.
 + `sageattn_varlen`: INT8 quantization for $QK^\top$ and FP16 for $PV$ using Triton backend. Support for varying sequence lengths within the same batch.
++ `sageattn` (XPU): Automatically dispatches to ARK sageV1 kernel via `auto-round-lib` when running on Intel GPU.
+  Supported head dimensions: 64, 128. Dtypes: FP16, BF16.
 
 For optimal speed and accuracy performance on custom devices and models, we strongly recommend referring to the [this file](./sageattention/core.py) for detailed guidance.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pip install torch torchvision torchaudio --index-url https://download.pytorch.or
 pip install auto-round-lib
 
 # 3. Install SageAttention (CUDA compilation skipped automatically on XPU)
-git clone https://github.com/luoyu-intel/SageAttention.git
+git clone https://github.com/thu-ml/SageAttention.git
 cd SageAttention
 python setup.py install
 ```

--- a/bench/bench_xpu.py
+++ b/bench/bench_xpu.py
@@ -1,0 +1,63 @@
+import argparse
+import math
+import time
+
+import torch
+
+from sageattention import sageattn
+
+parser = argparse.ArgumentParser(description="Benchmark QK Int8 PV FP16 on XPU")
+parser.add_argument("--batch_size", type=int, default=1, help="Batch size")
+parser.add_argument("--num_heads", type=int, default=96, help="Number of heads")
+parser.add_argument("--head_dim", type=int, default=128, help="Head dimension")
+parser.add_argument("--num_kv_heads", type=int, default=8, help="Number of KV heads")
+parser.add_argument("--seq_len", type=int, default=4096, help="Sequence length")
+parser.add_argument("--seq_len_kv", type=int, default=8192, help="KV sequence length")
+args = parser.parse_args()
+
+batch_size = args.batch_size
+num_heads = args.num_heads
+head_dim = args.head_dim
+num_kv_heads = args.num_kv_heads
+seq_len = args.seq_len
+seq_len_kv = args.seq_len_kv
+
+if not torch.xpu.is_available():
+    print("XPU not available, skipping benchmark.")
+    exit(0)
+
+print(f"XPU SageAttention Benchmark")
+print(
+    f"batch_size: {batch_size}, num_heads: {num_heads}, num_kv_heads: {num_kv_heads}, head_dim: {head_dim}"
+)
+print(f"seq_len: {seq_len}, seq_len_kv: {seq_len_kv}")
+
+q = torch.randn(
+    batch_size, num_heads, seq_len, head_dim, dtype=torch.float16, device="xpu"
+)
+k = torch.randn(
+    batch_size, num_kv_heads, seq_len_kv, head_dim, dtype=torch.float16, device="xpu"
+)
+v = torch.randn(
+    batch_size, num_kv_heads, seq_len_kv, head_dim, dtype=torch.float16, device="xpu"
+)
+scale = 1.0 / math.sqrt(head_dim)
+
+# Warmup
+for _ in range(5):
+    sageattn(q, k, v, is_causal=True, sm_scale=scale)
+torch.xpu.synchronize()
+
+# Benchmark
+N = 30
+st = time.time()
+for _ in range(N):
+    sageattn(q, k, v, is_causal=True, sm_scale=scale)
+torch.xpu.synchronize()
+t = (time.time() - st) / N * 1000
+
+print(f"Latency: {t:.3f} ms")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/bench_xpu.py
+++ b/bench/bench_xpu.py
@@ -57,7 +57,3 @@ torch.xpu.synchronize()
 t = (time.time() - st) / N * 1000
 
 print(f"Latency: {t:.3f} ms")
-
-
-if __name__ == "__main__":
-    main()

--- a/sageattention/core.py
+++ b/sageattention/core.py
@@ -44,10 +44,13 @@ try:
 except:
     SM90_ENABLED = False
 
-from .quant import per_block_int8 as per_block_int8_cuda
-from .quant import per_warp_int8 as per_warp_int8_cuda
-from .quant import sub_mean
-from .quant import per_channel_fp8
+try:
+    from .quant import per_block_int8 as per_block_int8_cuda
+    from .quant import per_warp_int8 as per_warp_int8_cuda
+    from .quant import sub_mean
+    from .quant import per_channel_fp8
+except ImportError:
+    pass
 
 from typing import Any, List, Literal, Optional, Tuple, Union
 import warnings
@@ -140,6 +143,32 @@ def sageattn(
     - All tensors must be on the same cuda device.
     """
         
+    # XPU dispatch via auto-round-lib
+    if q.device.type == "xpu":
+        try:
+            import auto_round_kernel as _ark
+        except ImportError:
+            raise ImportError("XPU detected but auto_round_kernel is not installed. Run: pip install auto-round-lib")
+        if "attn_mask" in kwargs and kwargs["attn_mask"] is not None:
+            mask = kwargs["attn_mask"]
+            if mask.dtype == torch.bool:
+                kwargs["attn_mask"] = torch.where(mask, 0.0, float("-inf")).to(torch.float32)
+        head_dim_og = q.size(-1)
+        if head_dim_og < 64:
+            q = torch.nn.functional.pad(q, (0, 64 - head_dim_og))
+            k = torch.nn.functional.pad(k, (0, 64 - head_dim_og))
+            v = torch.nn.functional.pad(v, (0, 64 - head_dim_og))
+        elif head_dim_og > 64 and head_dim_og < 128:
+            q = torch.nn.functional.pad(q, (0, 128 - head_dim_og))
+            k = torch.nn.functional.pad(k, (0, 128 - head_dim_og))
+            v = torch.nn.functional.pad(v, (0, 128 - head_dim_og))
+        elif head_dim_og > 128:
+            raise ValueError(f"Unsupported head_dim: {head_dim_og}")
+        out = _ark.sageattn(q, k, v, tensor_layout=tensor_layout, is_causal=is_causal, sm_scale=sm_scale, return_lse=return_lse, kernel="v1_pvhalf", **kwargs)
+        if return_lse:
+            return out[0][..., :head_dim_og], out[1]
+        return out[..., :head_dim_og]
+
     arch = get_cuda_arch_versions()[q.device.index]
     if arch == "sm80":
         return sageattn_qk_int8_pv_fp16_cuda(q, k, v, tensor_layout=tensor_layout, is_causal=is_causal, sm_scale=sm_scale, return_lse=return_lse, pv_accum_dtype="fp32")
@@ -395,7 +424,26 @@ def sageattn_varlen(
     - All tensors must be on the same cuda device.
     - `smooth_k` will introduce slight overhead but will improve the accuracy under most circumstances.
     """
-    
+
+    # XPU dispatch via auto-round-lib
+    if q.device.type == "xpu":
+        try:
+            import auto_round_kernel as _ark
+        except ImportError:
+            raise ImportError("XPU detected but auto_round_kernel is not installed. Run: pip install auto-round-lib")
+        head_dim_og = q.size(-1)
+        if head_dim_og < 64:
+            q = torch.nn.functional.pad(q, (0, 64 - head_dim_og))
+            k = torch.nn.functional.pad(k, (0, 64 - head_dim_og))
+            v = torch.nn.functional.pad(v, (0, 64 - head_dim_og))
+        elif head_dim_og > 64 and head_dim_og < 128:
+            q = torch.nn.functional.pad(q, (0, 128 - head_dim_og))
+            k = torch.nn.functional.pad(k, (0, 128 - head_dim_og))
+            v = torch.nn.functional.pad(v, (0, 128 - head_dim_og))
+        elif head_dim_og > 128:
+            raise ValueError(f"Unsupported head_dim: {head_dim_og}")
+        return _ark.sageattn_varlen(q, k, v, cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k, max_seqlen_q=max_seqlen_q, max_seqlen_k=max_seqlen_k, is_causal=is_causal, sm_scale=sm_scale, kernel="v1_pvhalf", smooth_k=smooth_k)[..., :head_dim_og]
+
     dtype = q.dtype
     assert q.is_cuda, "Input tensors must be on cuda."
     assert dtype in [torch.float16, torch.bfloat16], "Input tensors must be in dtype of torch.float16 or torch.bfloat16"

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,21 @@ from packaging.version import parse, Version
 
 from setuptools import setup, find_packages
 
-# Skip CUDA build in CI or when explicitly requested
+# Skip CUDA build on XPU or when explicitly requested
+_SKIP_XPU = False
+try:
+    import torch
+
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        print("[SageAttention] XPU detected - skipping CUDA compilation.")
+        print("[SageAttention] Install auto-round-lib: pip install auto-round-lib")
+        _SKIP_XPU = True
+except (ImportError, AttributeError):
+    pass
+
 SKIP_CUDA_BUILD = (
-    os.getenv("SAGEATTN_SKIP_CUDA_BUILD", "0").upper() in {"1", "TRUE", "YES"}
+    _SKIP_XPU
+    or os.getenv("SAGEATTN_SKIP_CUDA_BUILD", "0").upper() in {"1", "TRUE", "YES"}
     or ("sdist" in sys.argv)
 )
 


### PR DESCRIPTION
### Summary

Adds XPU support to SageAttention by detecting Intel GPUs and dispatching `sageattn()` and `sageattn_varlen()` to the ARK kernel backend (`auto-round-lib`). No CUDA compilation is required on XPU systems. The dispatch is transparent — users call `sageattn()` as usual and it automatically routes to the correct backend.

### Changes

**3 files, 85 insertions, 10 deletions**

| File | Change |
|------|--------|
| setup.py | Auto-detect XPU → skip CUDA compilation, print install hint for `auto-round-lib` |
| `sageattention/core.py` | `sageattn()`: XPU dispatch with head_dim auto-padding (<64→64, 64-128→128), bool mask → FP32 conversion. `sageattn_varlen()`: XPU dispatch with head_dim auto-padding. CUDA quant imports guarded with `try/except` for XPU-only environments. |
| README.md | Add Intel GPU (XPU) installation section and API documentation. |

### Design Decisions

1. **No CUDA kernel porting** — XPU uses `auto-round-lib` (ARK) as an external dependency, installed via `pip install auto-round-lib`. No SYCL code is added to this repository.
2. **Zero API breakage** — `sageattn(q, k, v, ...)` works identically on CUDA and XPU. The same parameters are accepted.
3. **head_dim auto-padding** — Models using head_dim=96 (e.g., some diffusion models) are automatically padded to 128 before dispatching to ARK, matching upstream behavior.
4. **bool mask support** — `torch.bool` attention masks are auto-converted to FP32 additive masks for ARK compatibility.

### Test Results

Same as ARK PR above (the fork routes to ARK, so performance is identical). Verified on Intel Arc Pro B60:

```
sageattn:            [1, 16, 4096, 128]
sageattn (hd=96):    [1, 16, 4096, 96]       # auto-padding
sageattn return_lse: O=[1, 16, 4096, 128], LSE=[1, 16, 4096]
sageattn_varlen:     [4096, 16, 128]
```

### Installation (XPU)

```bash
pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
pip install auto-round-lib
git clone https://github.com/luoyu-intel/SageAttention.git # for this PR
git clone https://github.com/thu-ml/SageAttention.git # after merge
cd SageAttention
python setup.py install   # CUDA compilation skipped automatically
```

### Performance (TOPS)
FLOPs = 4 × B × Hq × Sq × Sk × D (non-causal attention) · GPU: Intel Arc Pro B60 (BMG-G21) · FP16, non-causal
BMG theoretical peak: ~197 TOPS (INT8) / ~98 TFLOPS (FP16).

Config | torch.sdpa | ARK sdpa | ARK sagev1 | sagev1/ARK | sagev1/torch
-- | -- | -- | -- | -- | --
Sq=4096 Sk=4096 H=16 | 56.2 TOPS | 71.0 TOPS | 74.6 TOPS | 1.05× | 1.33×
Sq=8192 Sk=8192 H=16 | 57.5 TOPS | 81.1 TOPS | 91.0 TOPS | 1.12× | 1.58×
Sq=16384 Sk=16384 H=16 | 58.4 TOPS | 82.0 TOPS | 96.0 TOPS | 1.17× | 1.64×
Sq=4096 Sk=4096 H=96(8) GQA | 57.3 TOPS | 81.3 TOPS | 92.3 TOPS | 1.13× | 1.61×
Sq=4096 Sk=8192 H=96(8) GQA | 57.9 TOPS | 82.1 TOPS | 96.1 TOPS | 1.17× | 1.66×
Sq=4096 Sk=16384 H=96(8) GQA | 58.0 TOPS | 82.0 TOPS | 98.1 TOPS | 1.20× | 1.69×
Sq=4096 Sk=32768 H=96(8) GQA | 56.5 TOPS | 81.9 TOPS | 98.9 TOPS | 1.21× | 1.75×



